### PR TITLE
[CHORE]: enable CORS for React Frontend

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 # app/main.py
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.routes.ai_tagger import router as ai_router
 from app.core.logging import init_logging
 from app.core.config import settings
@@ -14,6 +15,16 @@ app = FastAPI(
     version=settings.VERSION,
     description=getattr(settings, "PROJECT_DESCRIPTION", None),
 )
+
+# 2.1) Enable CORS so the frontend at localhost:5173 can talk to the backend
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],  # your Vite dev server
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 # 3) Mount the AI-Tagger routes under /api
 app.include_router(

--- a/app/routes/ai_tagger.py
+++ b/app/routes/ai_tagger.py
@@ -32,7 +32,7 @@ async def ai_tag(file: UploadFile = File(...)):
         raise HTTPException(
             HTTP_400_BAD_REQUEST, detail="Only PDF files are accepted."
         )
-
+    print("pdf recieved ....")
     # 2) Read PDF bytes
     pdf_bytes = await file.read()
 


### PR DESCRIPTION
## 🔗 Issue References  
Closes #4 

---

## Description  
This PR addresses the CORS errors encountered when the React UI (served from `http://localhost:5173`) attempted to call our FastAPI endpoints on `http://127.0.0.1:8000`. It adds and configures Starlette’s `CORSMiddleware` in `app/main.py` so that the frontend can successfully communicate with the backend.

---

## Changes  

- **`app/main.py`**  
  - Imported `CORSMiddleware` from `fastapi.middleware.cors`  
  - Called `app.add_middleware(...)` before mounting routes with:  
    ```python
    allow_origins=["http://localhost:5173"],
    allow_methods=["*"],
    allow_headers=["*"],
    allow_credentials=True
    ```  
- Ensured middleware is applied prior to `app.include_router(...)`  

---

## ✅ Testing  
- Restarted Uvicorn (`uvicorn app.main:app --reload`) → no startup errors  
- From the React app:  
  - `POST /api/ai-tag` now succeeds without CORS errors  
  - `GET  /api/ping` responds correctly from the browser console  
- Verified manual test cases in the browser dev tools (Network tab shows CORS headers)

---

